### PR TITLE
[TASK] Remove isFrontendEditingActive check

### DIFF
--- a/Classes/Hooks/PageLoadedFromCacheHook.php
+++ b/Classes/Hooks/PageLoadedFromCacheHook.php
@@ -64,7 +64,6 @@ class PageLoadedFromCacheHook
             $context->getPropertyFromAspect('workspace', 'isOffline', false) === false &&
             strpos($uri, '?') === false &&
             $this->isAdminPanelVisible($frontendTypoScript) === false &&
-            $this->isFrontendEditingActive($tsfe) === false &&
             $request->getMethod() === 'GET'
         );
 
@@ -110,7 +109,6 @@ class PageLoadedFromCacheHook
             $context->getPropertyFromAspect('workspace', 'isOffline', false) === false &&
             strpos($uri, '?') === false &&
             $this->isAdminPanelVisible() === false &&
-            $this->isFrontendEditingActive($tsfe) === false &&
             $request->getMethod() === 'GET'
         );
 

--- a/Classes/Hooks/RequestAwareTrait.php
+++ b/Classes/Hooks/RequestAwareTrait.php
@@ -53,17 +53,6 @@ trait RequestAwareTrait
         );
     }
 
-    protected function isFrontendEditingActive(TypoScriptFrontendController $frontendController): bool
-    {
-        return (
-            /* Note: we do not use $GLOBALS['BE_USER']->isFrontendEditingActive() as that checks
-             * additional for adminPanel->isAdminModuleEnabled('edit'), but that has no influence
-             * on cache clearing. */
-            $frontendController->displayEditIcons == 1 ||
-            $frontendController->displayFieldEditIcons == 1
-        );
-    }
-
     protected function getUri(ServerRequestInterface $request): string
     {
         $normalizedParams = $this->getNormalizedParams($request);

--- a/Classes/Hooks/SetPageCacheHook.php
+++ b/Classes/Hooks/SetPageCacheHook.php
@@ -72,7 +72,6 @@ class SetPageCacheHook
             $tsfe !== null &&
             $tsfe->isStaticCacheble($request) &&
             $context->getPropertyFromAspect('workspace', 'isOffline', false) === false &&
-            $this->isFrontendEditingActive($tsfe) === false &&
             in_array('nginx_cache_ignore', $tags, true) === false
         );
 


### PR DESCRIPTION
This change removes the `isFrontendEditingActive` check, because it uses TSFE properties, which have been removed in TYPO3 v12.0.